### PR TITLE
Feat/#15 시간대 변경 UTC -> KST

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,23 +1,23 @@
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from datetime import datetime, timezone
+from datetime import datetime
+import pytz
 
 Base = declarative_base()
+KST = pytz.timezone("Asia/Seoul")
 
 
 class User(Base):
     __tablename__ = "user"
     id = Column(Integer, primary_key=True)
     nickname = Column(String(50), nullable=False)
-    created_at = Column(
-        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
-    )
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(KST))
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(KST),
+        onupdate=lambda: datetime.now(KST),
     )
     is_deleted = Column(Boolean, nullable=False, default=False)
 
@@ -31,14 +31,12 @@ class Mentor(Base):
     name = Column(String(50), nullable=False)
     description = Column(String(200), nullable=False)
     is_spicy = Column(Boolean, nullable=False, default=False)
-    created_at = Column(
-        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
-    )
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(KST))
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(KST),
+        onupdate=lambda: datetime.now(KST),
     )
     is_deleted = Column(Boolean, nullable=False, default=False)
 
@@ -52,14 +50,12 @@ class Prescription(Base):
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
     mentor_id = Column(Integer, ForeignKey("mentor.id"), nullable=False)
     content = Column(String(500), nullable=False)
-    created_at = Column(
-        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
-    )
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(KST))
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(KST),
+        onupdate=lambda: datetime.now(KST),
     )
     is_deleted = Column(Boolean, nullable=False, default=False)
 
@@ -72,14 +68,12 @@ class Chatroom(Base):
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
     mentor_id = Column(Integer, ForeignKey("mentor.id"), nullable=False)
-    created_at = Column(
-        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
-    )
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(KST))
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(KST),
+        onupdate=lambda: datetime.now(KST),
     )
     is_deleted = Column(Boolean, nullable=False, default=False)
 
@@ -94,14 +88,12 @@ class Chat(Base):
     chatroom_id = Column(Integer, ForeignKey("chatroom.id"), nullable=False)
     content = Column(String(1000), nullable=False)
     is_user = Column(Boolean, nullable=False)
-    created_at = Column(
-        DateTime, nullable=False, default=lambda: datetime.now(timezone.utc)
-    )
+    created_at = Column(DateTime, nullable=False, default=lambda: datetime.now(KST))
     updated_at = Column(
         DateTime,
         nullable=False,
-        default=lambda: datetime.now(timezone.utc),
-        onupdate=lambda: datetime.now(timezone.utc),
+        default=lambda: datetime.now(KST),
+        onupdate=lambda: datetime.now(KST),
     )
     is_deleted = Column(Boolean, nullable=False, default=False)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydantic
 pydantic-settings
 pymysql
 cryptography
+pytz


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #15 

## 📝 작업 내용
- DB에 저장되는 created_at과 updated_at이 UTC가 아닌 KST 기준으로 처리되도록 수정

## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
- 사용자를 만들고 받은 응답
  <img width="368" alt="image" src="https://github.com/2024-Summer-Bootcamp-TeamJ/Backend/assets/68285620/c205b338-e554-408f-80c8-4599e47fc56b">
- 같은 시각 PC에 표시되는 대한민국 표준시
  ![image](https://github.com/2024-Summer-Bootcamp-TeamJ/Backend/assets/68285620/84e84e50-eb01-4459-b78e-025f144ce370)


## 💬 리뷰 요구사항(선택)
- requirements.txt에 시간대 관련 라이브러리 `pytz`가 추가되었습니다.

close #15 