### PR TITLE
[feat] web socket 채팅방과 CRUD 연동

### DIFF
--- a/app/crud/chatroom.py
+++ b/app/crud/chatroom.py
@@ -13,8 +13,8 @@ def create_chatroom(db: Session, chatroom: ChatroomCreate):
 
 def get_chatroom(db: Session, chatroom_id: int):
     db_chatroom = db.query(Chatroom).filter(Chatroom.id == chatroom_id).first()
-    if db_chatroom.is_deleted:
-        return
+    if db_chatroom is None or db_chatroom.is_deleted:
+        return None
     return db_chatroom
 
 

--- a/app/routers.py
+++ b/app/routers.py
@@ -139,9 +139,9 @@ async def websocket_endpoint(
         {
             "event": "connect",
             "message": "connected",
-            "user_id": {user_id},
-            "chatroom_id": {chatroom_id},
-            "mentor_id": {chatroom.mentor_id},
+            "user_id": user_id,
+            "chatroom_id": chatroom_id,
+            "mentor_id": chatroom.mentor_id,
         }
     )
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,19 +14,33 @@
     <ul id='messages'>
     </ul>
     <script>
-        var ws = new WebSocket("ws://localhost:8000/api/ws/chat");
+        var ws = new WebSocket("ws://localhost:8000/api/ws/chatrooms/1?user_id=1");
 
         ws.onmessage = (event) => {
             const data = JSON.parse(event.data);
             const eventType = data.event;
             console.log(eventType);
-
-            if (eventType === 'connect') {
-                const message = data.message;
+            if (eventType == "disconnect"){
                 var messages = document.getElementById('messages');
                 var messageLi = document.createElement('li');
                 messageLi.appendChild(document.createTextNode(data.message));
                 messages.appendChild(messageLi);
+            }
+            if (eventType === 'connect') {
+                console.log(data)
+                var messages = document.getElementById('messages');
+                var messageLi = document.createElement('li');
+                var userLi = document.createElement('li');
+                var chatroomLi = document.createElement('li');
+                var mentorLi = document.createElement('li');
+                messageLi.appendChild(document.createTextNode(data.message));
+                messages.appendChild(messageLi);
+                userLi.appendChild(document.createTextNode("user_id : " + data.user_id));
+                messages.appendChild(userLi);
+                chatroomLi.appendChild(document.createTextNode("chatroom_id : " + data.chatroom_id));
+                messages.appendChild(chatroomLi);
+                mentorLi.appendChild(document.createTextNode("mentor_id : " + data.mentor_id));
+                messages.appendChild(mentorLi);
             }
             else if (eventType === 'server_message') {
                 console.log(data.message)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호
#24 
## 📝 작업 내용
- 유저 및 채팅방 검증
- 오류 시 사용자에게 보내고 소켓 종료

## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
<img width="752" alt="image" src="https://github.com/2024-Summer-Bootcamp-TeamJ/Backend/assets/132903799/b77e7fc8-6a97-4790-a19f-fa6c7b8f908f">
-연결 성공 시
<img width="754" alt="image" src="https://github.com/2024-Summer-Bootcamp-TeamJ/Backend/assets/132903799/528ab21c-1c89-4eb0-9b3e-ecfa59f070f2">
-채팅방 없을 시
<img width="753" alt="image" src="https://github.com/2024-Summer-Bootcamp-TeamJ/Backend/assets/132903799/d4f71553-af0c-4f5c-959f-62080f5c7bfb">
-채팅방은 있지만 유저 없을 시
<img width="749" alt="image" src="https://github.com/2024-Summer-Bootcamp-TeamJ/Backend/assets/132903799/8440eb27-25b7-4f9c-867c-a9a8d366411f">
-유저도 없고 채팅방도 없을 시
## 💬 리뷰 요구사항(선택)
채팅방도 없고 유저도 없으면 둘다 오류뜨게 해야하나요?

close #24 