### PR TITLE
fix: No text to send to TTS API 오류 해결

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -111,8 +111,10 @@ How would you respond to the question: "{question}"?
                 db, chatroom_id=chatroom_id, is_user=False, content=server_message
             )
 
+            # 음성을 생성하는 celery task 실행
             task_audio = celery_worker.generate_audio_from_string.delay(
-                re.sub(r"[^\uAC00-\uD7A30-9a-zA-Z\s]", "", server_message)
+                # 한글, 영어, 숫자, 공백만 남기고 제거
+                re.sub(r"[^\uAC00-\uD7A3a-zA-Z0-9 ]", "", server_message)
             )
 
             server_audio = task_audio.get()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #70  

## 📝 작업 내용
- No text to send to TTS API 오류 해결
  - 이전 코드에서는 탭, 개행문자가 포함되어도 걸러지지 않음
  - 한글, 영어, 숫자, 공백을 제외한 모든 문자를 필터링


## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
없음

## 💬 리뷰 요구사항(선택)
없음
