### PR TITLE
Feat/#99 처방전 방식에서 편지 방식으로 변경

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -119,7 +119,7 @@ async def websocket_endpoint(
     # 연결이 끊어졌을 때
     except WebSocketDisconnect:
 
-        prompt = """Create a brief prescription-style summary in Korean based on the following conversation between a client and a counselor.
+        prompt = """Create a brief letter-style summary that a counselor sends to a client in Korean based on the following conversation.
 The summary should provide a concise solution derived from the conversation.
 Limit the length of the summary to no more than a few sentences.
 Conversation : """ + json.dumps(


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #99 

## 📝 작업 내용
- 멘토가 사용자에게 주는 요약본을 처방전 스타일에서 편지 스타일로 변경

## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
- 대화 내용
  <img width="933" alt="image" src="https://github.com/user-attachments/assets/3f29298d-1102-4d84-8b06-3d4f9436419c">

- 처방전
  <img width="928" alt="image" src="https://github.com/user-attachments/assets/8da31154-98ac-4590-b813-57a2f9b4b2c0">


## 💬 리뷰 요구사항(선택)
없음