### PR TITLE
feat: grafana를 nginx와 연결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf
     depends_on:
       - teamj_backend
+      - grafana
 
   prometheus:
     image: prom/prometheus:latest
@@ -136,7 +137,7 @@ services:
     volumes:
       - ./grafana:/etc/grafana/provisioning
       - ./grafana/data:/var/lib/grafana
-    ports:
+    expose:
       - "3000:3000"
     depends_on:
       - prometheus

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,9 +2,14 @@
 events {}  
 
 http {
-    # 업스트림 서버 그룹 정의
+    # backend 업스트림 그룹 정의
     upstream backend {
         server teamj_backend:8000;
+    }
+
+    # grafana 업스트림 그룹 정의
+    upstream grafana {
+        server grafana:3000;
     }
 
     server {
@@ -30,10 +35,21 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        location /stub_status{
+        # nginx 모니터링을 위한 설정
+        location /stub_status {
             stub_status;
             allow 127.0.0.1;
             allow 172.18.0.0/16;
+        }
+
+        # '/' 경로에 대한 요청을 처리
+        location / {
+            proxy_pass http://grafana/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #123 

## 📝 작업 내용
- grafana로 보내는 요청이 nginx를 거쳐서 가도록 수정

## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
- 없음

## 💬 리뷰 요구사항(선택)
- 없음
