### PR TITLE
Feat/#130 grafana endpoint "/" -> "/monitoring"으로 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
     volumes:
       - ./grafana:/etc/grafana/provisioning
       - ./grafana/data:/var/lib/grafana
+      - ./grafana/grafana.ini:/etc/grafana/grafana.ini
     expose:
       - "3000:3000"
     depends_on:

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,8 +42,8 @@ http {
             allow 172.18.0.0/16;
         }
 
-        # '/' 경로에 대한 요청을 처리
-        location / {
+        # '/monitoring' 경로에 대한 요청을 처리
+        location /monitoring/ {
             proxy_pass http://grafana/;
             proxy_http_version 1.1;
             proxy_set_header Host $host;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #130 

## 📝 작업 내용
- grafana endpoint "/" -> "/monitoring"으로 수정
- grafana.db를 주입시켰을때 dashboard가 조회되지 않는 문제 수정

## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
- 없음

## 💬 리뷰 요구사항(선택)
- 없음
