### PR TITLE
chore: mysql-exporter 제거

### DIFF
--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -17,9 +17,6 @@ scrape_configs:
   - job_name: 'cAdvisor-data' 
     static_configs:  
       - targets: ['cadvisor:8080']
-  - job_name: 'mysql-data' 
-    static_configs: 
-      - targets: ['mysql-exporter:9104']
   - job_name: 'rabbitmq-data' 
     static_configs: 
       - targets: ['rabbitmq:15692']


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #143 

## 📝 작업 내용
- 프로메테우스 설정 파일에 mysql-exporter 제거

## 체크리스트
- [x] 포메팅이 적용되었습니다.

## 스크린샷 (선택)
- 없음

## 💬 리뷰 요구사항(선택)
- 없음
